### PR TITLE
fix: Replace hardcoded repository references in pr.yml

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -145,7 +145,7 @@ jobs:
         with:
           script: |
             const prNumber = ${{ steps.pr.outputs.number }};
-            const previewUrl = `https://gfxblit.github.io/SnakeClaude/pr-${prNumber}/`;
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-${prNumber}/`;
 
             github.rest.issues.createComment({
               owner: context.repo.owner,
@@ -162,7 +162,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: production
-      url: https://gfxblit.github.io/SnakeClaude/
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/
 
     steps:
       - name: Checkout gh-pages branch


### PR DESCRIPTION
## Summary
- Replaces hardcoded 'SnakeClaude' repository name in preview URL with dynamic `context.repo` values
- Replaces hardcoded repository owner/name in production environment URL with GitHub variables
- Makes the workflow portable across different repositories without requiring manual updates

## Changes
- Line 148: Preview URL now uses `${context.repo.owner}` and `${context.repo.repo}`
- Line 165: Production URL now uses `${{ github.repository_owner }}` and `${{ github.event.repository.name }}`

## Test plan
- Verify workflow syntax is valid
- Confirm preview deployments generate correct URLs
- Verify production environment URL is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)