### PR TITLE
feat: Configure Supabase env vars for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,6 +85,10 @@ jobs:
         run: npm install
 
       - name: Build
+        # Vite embeds env vars at build time. Anon key is safe to expose client-side; RLS policies enforce security.
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
         run: npm run build
 
       - name: Upload Build Artifact


### PR DESCRIPTION
Add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY environment variables to the build step in the CI workflow. Vite embeds these at build time, enabling deployed apps to connect to production Supabase.

The anon key is safe to expose client-side as security is enforced through Row Level Security (RLS) policies in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)