### PR TITLE
fix: Add base path for GitHub Pages deployment

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: '/EastVsWest/',
   root: '.',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- Fixed GitHub Pages deployment by adding `base: '/EastVsWest/'` to `vite.config.js`

## Problem
After merging changes to main, the deployed site at https://gfxblit.github.io/EastVsWest/ was still showing old content. The CI/CD pipeline was running successfully and deploying to gh-pages, but the assets weren't loading correctly.

## Root Cause
Vite was building with absolute asset paths (`/assets/...`) instead of repository-relative paths (`/EastVsWest/assets/...`). This caused 404 errors when loading assets on GitHub Pages, which serves the app from a subdirectory.

## Solution
Added `base: '/EastVsWest/'` configuration to `vite.config.js` so Vite generates correct asset paths for GitHub Pages deployment.

## Verification
After merging this PR:
1. The CI/CD pipeline will rebuild with the correct base path
2. Assets will load from `/EastVsWest/assets/...` instead of `/assets/...`
3. The deployed site will show the latest changes including the lobby background image

🤖 Generated with [Claude Code](https://claude.com/claude-code)