### PR TITLE
feat(ci): add local supabase setup to claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,6 +72,11 @@ jobs:
           echo "VITE_SUPABASE_URL=$API_URL" >> $GITHUB_ENV
           echo "VITE_SUPABASE_ANON_KEY=$ANON_KEY" >> $GITHUB_ENV
 
+      - name: Verify Supabase connection
+        run: |
+          echo "Testing connection to Supabase at $SUPABASE_URL"
+          curl -f $SUPABASE_URL/rest/v1/ -H "apikey: $SUPABASE_ANON_KEY" || exit 1
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
This PR adds a local Supabase setup to the Claude workflow to ensure Claude has access to a functional backend for development and testing without using production credentials.

Key changes:
- Installs Supabase CLI.
- Starts a local Supabase instance during the workflow.
- Exports local VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to the environment for Claude Code action.
- Installs project dependencies using npm ci.