### PR TITLE
feat: enable npm command execution in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -100,5 +100,5 @@ jobs:
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          claude_args: '--allowed-tools "Bash(npm:*)"'
 


### PR DESCRIPTION
- Uncomment and configure claude_args to allow Bash(npm:*) tools
- This enables Claude to run npm commands like 'npm run test:e2e'
- Addresses permission issue identified in #34