### PR TITLE
fix: Ensure client position updates are processed by host

### DIFF
--- a/src/SessionPlayersSnapshot.js
+++ b/src/SessionPlayersSnapshot.js
@@ -113,7 +113,10 @@ export class SessionPlayersSnapshot {
   #handleBroadcast(message) {
     // Handle position_update (individual player update)
     if (message.type === 'position_update') {
-      this.#handlePositionUpdate(message.data);
+      this.#handlePositionUpdate({
+        ...message.data,
+        player_id: message.from,
+      });
     }
     // Handle position_broadcast (batched updates from host)
     else if (message.type === 'position_broadcast') {

--- a/src/SessionPlayersSnapshot.test.js
+++ b/src/SessionPlayersSnapshot.test.js
@@ -268,7 +268,6 @@ describe('SessionPlayersSnapshot (Built on Network)', () => {
         type: 'position_update',
         from: TEST_PLAYER_ID,
         data: {
-          player_id: TEST_PLAYER_ID,
           position_x: 300,
           position_y: 400,
           rotation: 1.57,
@@ -305,7 +304,6 @@ describe('SessionPlayersSnapshot (Built on Network)', () => {
         type: 'position_update',
         from: 'unknown-player-id',
         data: {
-          player_id: 'unknown-player-id',
           position_x: 300,
           position_y: 400,
         },


### PR DESCRIPTION
This PR fixes a bug where client position updates were ignored by the host. The `SessionPlayersSnapshot` class now correctly uses the sender's ID from the message envelope.