### PR TITLE
feat(input): support position-based WASD controls

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -166,13 +166,13 @@ export const CONFIG = {
   // Input Settings
   INPUT: {
     KEYBOARD_MOVE_KEYS: {
-      w: { x: 0, y: -1 },
-      a: { x: -1, y: 0 },
-      s: { x: 0, y: 1 },
-      d: { x: 1, y: 0 },
+      KeyW: { x: 0, y: -1 },
+      KeyA: { x: -1, y: 0 },
+      KeyS: { x: 0, y: 1 },
+      KeyD: { x: 1, y: 0 },
     },
-    SPECIAL_ABILITY_KEY: 'q',
-    INTERACT_KEY: 'f',
+    SPECIAL_ABILITY_KEY: 'KeyQ',
+    INTERACT_KEY: 'KeyF',
     MAX_JOYSTICK_DISTANCE: 45, // Maximum distance for virtual joystick movement
   },
 

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -47,12 +47,12 @@ describe('CONFIG', () => {
     expect(CONFIG.ARMOR.PLATED.weaknesses).toBeDefined();
   });
 
-  test('should have input settings defined', () => {
-    expect(CONFIG.INPUT).toBeDefined();
-    expect(CONFIG.INPUT.KEYBOARD_MOVE_KEYS).toBeDefined();
-    expect(CONFIG.INPUT.SPECIAL_ABILITY_KEY).toBe('q');
-    expect(CONFIG.INPUT.INTERACT_KEY).toBe('f');
-  });
+    test('WhenCheckingInputConfig_ShouldHaveCorrectDefaults', () => {
+      expect(CONFIG.INPUT.KEYBOARD_MOVE_KEYS).toBeDefined();
+      expect(CONFIG.INPUT.SPECIAL_ABILITY_KEY).toBe('KeyQ');
+      expect(CONFIG.INPUT.INTERACT_KEY).toBe('KeyF');
+      expect(CONFIG.INPUT.MAX_JOYSTICK_DISTANCE).toBe(45);
+    });
 
   test('double-handed weapons should have stance property set correctly', () => {
     const doubleHandedWeapons = [

--- a/src/input.js
+++ b/src/input.js
@@ -60,7 +60,7 @@ export class Input {
   }
 
   handleKeyDown(event) {
-    const key = event.key.toLowerCase();
+    const key = event.code;
     this.keysPressed.add(key);
     this.updateMovement();
 
@@ -75,7 +75,7 @@ export class Input {
   }
 
   handleKeyUp(event) {
-    const key = event.key.toLowerCase();
+    const key = event.code;
     this.keysPressed.delete(key);
     this.updateMovement();
 

--- a/src/input.test.js
+++ b/src/input.test.js
@@ -80,66 +80,69 @@ describe('Input', () => {
     });
 
     test('WhenWKeyPressed_ShouldUpdateMoveY', () => {
-      const event = new KeyboardEvent('keydown', { key: 'w' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(event);
 
       expect(input.inputState.moveY).toBe(-1);
     });
 
     test('WhenAKeyPressed_ShouldUpdateMoveX', () => {
-      const event = new KeyboardEvent('keydown', { key: 'a' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyA' });
       input.handleKeyDown(event);
 
       expect(input.inputState.moveX).toBe(-1);
     });
 
     test('WhenSKeyPressed_ShouldUpdateMoveY', () => {
-      const event = new KeyboardEvent('keydown', { key: 's' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyS' });
       input.handleKeyDown(event);
 
       expect(input.inputState.moveY).toBe(1);
     });
 
     test('WhenDKeyPressed_ShouldUpdateMoveX', () => {
-      const event = new KeyboardEvent('keydown', { key: 'd' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyD' });
       input.handleKeyDown(event);
 
       expect(input.inputState.moveX).toBe(1);
     });
 
     test('WhenSpecialAbilityKeyPressed_ShouldSetSpecialAbilityTrue', () => {
-      const event = new KeyboardEvent('keydown', { key: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
+      const event = new KeyboardEvent('keydown', { code: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
       input.handleKeyDown(event);
 
       expect(input.inputState.specialAbility).toBe(true);
     });
 
     test('WhenInteractKeyPressed_ShouldSetInteractTrue', () => {
-      const event = new KeyboardEvent('keydown', { key: CONFIG.INPUT.INTERACT_KEY });
+      const event = new KeyboardEvent('keydown', { code: CONFIG.INPUT.INTERACT_KEY });
       input.handleKeyDown(event);
 
       expect(input.inputState.interact).toBe(true);
     });
 
     test('WhenKeyPressed_ShouldAddToKeysPressed', () => {
-      const event = new KeyboardEvent('keydown', { key: 'w' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(event);
 
-      expect(input.keysPressed.has('w')).toBe(true);
+      expect(input.keysPressed.has('KeyW')).toBe(true);
     });
 
     test('WhenKeyPressed_ShouldCallCallback', () => {
-      const event = new KeyboardEvent('keydown', { key: 'w' });
+      const event = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(event);
 
       expect(mockCallback).toHaveBeenCalled();
     });
 
-    test('WhenUppercaseKey_ShouldConvertToLowercase', () => {
-      const event = new KeyboardEvent('keydown', { key: 'W' });
+    test('WhenDvorakLayoutUsed_ShouldStillMoveBasedOnPhysicalPosition', () => {
+      // On Dvorak, physical 'W' key produces ','
+      const event = new KeyboardEvent('keydown', { 
+        key: ',', 
+        code: 'KeyW' 
+      });
       input.handleKeyDown(event);
 
-      expect(input.keysPressed.has('w')).toBe(true);
       expect(input.inputState.moveY).toBe(-1);
     });
   });
@@ -151,44 +154,44 @@ describe('Input', () => {
 
     test('WhenWKeyReleased_ShouldResetMoveY', () => {
       // Press W
-      const downEvent = new KeyboardEvent('keydown', { key: 'w' });
+      const downEvent = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(downEvent);
 
       // Release W
-      const upEvent = new KeyboardEvent('keyup', { key: 'w' });
+      const upEvent = new KeyboardEvent('keyup', { code: 'KeyW' });
       input.handleKeyUp(upEvent);
 
       expect(input.inputState.moveY).toBe(0);
     });
 
     test('WhenSpecialAbilityKeyReleased_ShouldSetSpecialAbilityFalse', () => {
-      const downEvent = new KeyboardEvent('keydown', { key: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
+      const downEvent = new KeyboardEvent('keydown', { code: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
       input.handleKeyDown(downEvent);
 
-      const upEvent = new KeyboardEvent('keyup', { key: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
+      const upEvent = new KeyboardEvent('keyup', { code: CONFIG.INPUT.SPECIAL_ABILITY_KEY });
       input.handleKeyUp(upEvent);
 
       expect(input.inputState.specialAbility).toBe(false);
     });
 
     test('WhenInteractKeyReleased_ShouldSetInteractFalse', () => {
-      const downEvent = new KeyboardEvent('keydown', { key: CONFIG.INPUT.INTERACT_KEY });
+      const downEvent = new KeyboardEvent('keydown', { code: CONFIG.INPUT.INTERACT_KEY });
       input.handleKeyDown(downEvent);
 
-      const upEvent = new KeyboardEvent('keyup', { key: CONFIG.INPUT.INTERACT_KEY });
+      const upEvent = new KeyboardEvent('keyup', { code: CONFIG.INPUT.INTERACT_KEY });
       input.handleKeyUp(upEvent);
 
       expect(input.inputState.interact).toBe(false);
     });
 
     test('WhenKeyReleased_ShouldRemoveFromKeysPressed', () => {
-      const downEvent = new KeyboardEvent('keydown', { key: 'w' });
+      const downEvent = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(downEvent);
 
-      const upEvent = new KeyboardEvent('keyup', { key: 'w' });
+      const upEvent = new KeyboardEvent('keyup', { code: 'KeyW' });
       input.handleKeyUp(upEvent);
 
-      expect(input.keysPressed.has('w')).toBe(false);
+      expect(input.keysPressed.has('KeyW')).toBe(false);
     });
   });
 
@@ -198,8 +201,8 @@ describe('Input', () => {
     });
 
     test('WhenWAndDPressed_ShouldNormalizeDiagonalMovement', () => {
-      input.keysPressed.add('w');
-      input.keysPressed.add('d');
+      input.keysPressed.add('KeyW');
+      input.keysPressed.add('KeyD');
       input.updateMovement();
 
       const magnitude = Math.sqrt(
@@ -209,16 +212,16 @@ describe('Input', () => {
     });
 
     test('WhenWAndSPressed_ShouldCancelVerticalMovement', () => {
-      input.keysPressed.add('w');
-      input.keysPressed.add('s');
+      input.keysPressed.add('KeyW');
+      input.keysPressed.add('KeyS');
       input.updateMovement();
 
       expect(input.inputState.moveY).toBe(0);
     });
 
     test('WhenAAndDPressed_ShouldCancelHorizontalMovement', () => {
-      input.keysPressed.add('a');
-      input.keysPressed.add('d');
+      input.keysPressed.add('KeyA');
+      input.keysPressed.add('KeyD');
       input.updateMovement();
 
       expect(input.inputState.moveX).toBe(0);
@@ -796,7 +799,7 @@ describe('Input', () => {
 
     test('WhenTouchActive_ShouldOverrideKeyboardInput', () => {
       // Press keyboard keys
-      const keyEvent = new KeyboardEvent('keydown', { key: 'w' });
+      const keyEvent = new KeyboardEvent('keydown', { code: 'KeyW' });
       input.handleKeyDown(keyEvent);
 
       // Verify keyboard sets movement


### PR DESCRIPTION
This PR implements position-based keyboard controls (scancodes via KeyboardEvent.code) to ensure that users with alternative keyboard layouts (e.g., Dvorak, AZERTY) can use the standard "WASD" hand position for movement.

- Updated `src/config.js` to use scancodes for movement and action keys.
- Updated `src/input.js` to use `event.code` instead of `event.key`.
- Updated unit tests to verify scancode support and alternative layout compatibility.

Closes #60