### PR TITLE
Disable use_gemini_code_assist in gemini.yml

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -268,7 +268,7 @@ jobs:
             Remember, you are running in a virtual machine and no one reviewing your output. Your review must be posted to GitHub using the MCP tools to create a pending review, add comments to the pending review, and submit the pending review.
         with:
           # Authentication
-          use_gemini_code_assist: true
+          # use_gemini_code_assist: true
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
 
           # Model Configuration


### PR DESCRIPTION
Comment out the use_gemini_code_assist option in the workflow.