### PR TITLE
chore: Implement graceful model fallback and command-based review

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -155,8 +155,11 @@ jobs:
                 "core": [
                   "run_shell_command(cat)",
                   "run_shell_command(echo)",
+                  "run_shell_command(gh)",
+                  "run_shell_command(git)",
                   "run_shell_command(grep)",
                   "run_shell_command(head)",
+                  "run_shell_command(ls)",
                   "run_shell_command(tail)"
                 ]
               }
@@ -218,8 +221,11 @@ jobs:
                 "core": [
                   "run_shell_command(cat)",
                   "run_shell_command(echo)",
+                  "run_shell_command(gh)",
+                  "run_shell_command(git)",
                   "run_shell_command(grep)",
                   "run_shell_command(head)",
+                  "run_shell_command(ls)",
                   "run_shell_command(tail)"
                 ]
               }
@@ -280,8 +286,11 @@ jobs:
                 "core": [
                   "run_shell_command(cat)",
                   "run_shell_command(echo)",
+                  "run_shell_command(gh)",
+                  "run_shell_command(git)",
                   "run_shell_command(grep)",
                   "run_shell_command(head)",
+                  "run_shell_command(ls)",
                   "run_shell_command(tail)"
                 ]
               }


### PR DESCRIPTION
## Changes
- Implemented a **manual model fallback sequence** in the GitHub Action workflow:  ->  -> .
- Refactored the PR review logic to use the externalized command file at .
- Expanded **allowed tools** for the Gemini agent to include Work seamlessly with GitHub from the command line.
