### PR TITLE
fix(workflow): Enforce gh api usage for Gemini response visibility

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -180,11 +180,14 @@ jobs:
              - For code changes: `git add <files>`, `git commit -m "<message>\n\nCo-authored-by: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>"`, `git push origin HEAD`
 
           3. Final Summary:
-             - Remove the spinner and post a final summary in the same comment.
+             - Remove the spinner and post a final summary in the same comment using `gh api`.
+             - **MANDATORY**: You MUST execute the `gh api` command to make this summary visible. Just generating the text is not enough.
              - Always include: [View job run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           Important Notes:
-          - Communicate ONLY by updating your single acknowledgement comment.
+          - **CRITICAL**: Your standard text output is NOT posted to GitHub. The user will NOT see anything you write unless you explicitly use the `gh api` command to update the comment.
+          - **ALWAYS** ends your execution by updating the comment one last time with the final result.
+          - Communicate ONLY by updating your single acknowledgement comment (ID: ${{ steps.acknowledge.outputs.comment_id }}).
           - REPOSITORY SETUP: Follow GEMINI.md for repo-specific setup and standards.
           PROMPT_CONTENT
           echo "EOF" >> $GITHUB_ENV


### PR DESCRIPTION
## Problem
Gemini's progress and final results were not visible in the GitHub PR comment thread because the model was outputting text to stdout/logs instead of explicitly updating the comment via the GitHub API.

## Solution
Modified the `.github/workflows/gemini.yml` system prompt to:
- Explicitly mandate the use of `gh api` for the final summary.
- Include a critical warning that standard text output is invisible to users.
- Reinforce the communication protocol for updating the single acknowledgement comment.

## Verification
Manually reviewed the workflow file changes.