### PR TITLE
feat(ui): update attack/special buttons with cooldowns and equipment state

### DIFF
--- a/src/LocalPlayerController.js
+++ b/src/LocalPlayerController.js
@@ -242,4 +242,36 @@ export class LocalPlayerController {
       this.player.rotation -= 2 * Math.PI;
     }
   }
+
+  getCooldownStatus() {
+    if (!this.player) return { attackPct: 0, abilityPct: 0 };
+
+    const now = Date.now();
+    const weaponId = this.player.weapon;
+    // Default to fist if weapon is null/invalid for cooldown calculation purposes, 
+    // although UI might disable buttons if weapon is null.
+    // However, if we do have a weapon (even fist), we want to show cooldowns.
+    const weaponConfig = Object.values(CONFIG.WEAPONS).find(w => w.id === weaponId) || CONFIG.WEAPONS.FIST;
+
+    const attackCooldown = 1000 / weaponConfig.attackSpeed;
+    const specialCooldown = CONFIG.COMBAT.SPECIAL_ABILITY_COOLDOWN_MS;
+
+    const attackElapsed = now - this.player.lastAttackTime;
+    const specialElapsed = now - this.player.lastSpecialTime;
+
+    let attackPct = 0;
+    if (attackElapsed < attackCooldown) {
+      attackPct = 1 - (attackElapsed / attackCooldown);
+    }
+
+    let abilityPct = 0;
+    if (specialElapsed < specialCooldown) {
+      abilityPct = 1 - (specialElapsed / specialCooldown);
+    }
+
+    return {
+      attackPct: Math.max(0, Math.min(1, attackPct)),
+      abilityPct: Math.max(0, Math.min(1, abilityPct))
+    };
+  }
 }

--- a/src/LocalPlayerController.test.js
+++ b/src/LocalPlayerController.test.js
@@ -79,4 +79,43 @@ describe('LocalPlayerController', () => {
     expect(player.health).toBe(50);
     expect(player.weapon).toBe('spear');
   });
+
+  describe('getCooldownStatus', () => {
+    beforeEach(() => {
+      controller = new LocalPlayerController(mockNetwork, null);
+    });
+
+    test('WhenNoCooldown_ShouldReturnZeros', () => {
+      const status = controller.getCooldownStatus();
+      expect(status.attackPct).toBe(0);
+      expect(status.abilityPct).toBe(0);
+    });
+
+    test('WhenAttackOnCooldown_ShouldReturnPercentage', () => {
+      const player = controller.getPlayer();
+      const now = Date.now();
+      
+      // Mock weapon with 1.0 attack speed (1000ms cooldown)
+      player.weapon = 'spear'; 
+      player.lastAttackTime = now - 500; // Halfway through cooldown
+
+      const status = controller.getCooldownStatus();
+      
+      // Should be around 0.5 (50%)
+      expect(status.attackPct).toBeCloseTo(0.5, 1);
+    });
+
+    test('WhenSpecialOnCooldown_ShouldReturnPercentage', () => {
+      const player = controller.getPlayer();
+      const now = Date.now();
+      
+      // Special cooldown is 3000ms by default
+      const cooldown = CONFIG.COMBAT.SPECIAL_ABILITY_COOLDOWN_MS;
+      player.lastSpecialTime = now - (cooldown / 2); // Halfway
+
+      const status = controller.getCooldownStatus();
+      
+      expect(status.abilityPct).toBeCloseTo(0.5, 1);
+    });
+  });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -43,6 +43,8 @@ class App {
     this.running = false;
     this.lastTimestamp = 0;
     this.animationFrameId = null;
+    this.lastWeaponId = null;
+    this.lastArmorId = null;
   }
 
   async init() {
@@ -475,6 +477,33 @@ class App {
     const localPlayer = this.game.getLocalPlayer();
     if (localPlayer && this.camera) {
       this.camera.update(localPlayer.x, localPlayer.y, CONFIG.CAMERA.LERP_FACTOR);
+    }
+
+    // Update UI
+    if (localPlayer) {
+      this.ui.updateHealth(localPlayer.health);
+      
+      // Update cooldowns
+      if (this.game.localPlayerController) {
+        const cooldowns = this.game.localPlayerController.getCooldownStatus();
+        this.ui.updateCooldowns(cooldowns.attackPct, cooldowns.abilityPct);
+      }
+
+      // Check for equipment changes
+      // We store the last known equipment on the App instance to avoid unnecessary DOM updates
+      const currentWeaponId = localPlayer.weapon;
+      const currentArmorId = localPlayer.armor;
+
+      if (this.lastWeaponId !== currentWeaponId || this.lastArmorId !== currentArmorId) {
+        const weaponConfig = currentWeaponId ? Object.values(CONFIG.WEAPONS).find(w => w.id === currentWeaponId) : null;
+        const armorConfig = currentArmorId ? Object.values(CONFIG.ARMOR).find(a => a.id === currentArmorId) : null;
+        
+        this.ui.updateEquipment(weaponConfig, armorConfig);
+        this.ui.updateActionButtons(weaponConfig);
+        
+        this.lastWeaponId = currentWeaponId;
+        this.lastArmorId = currentArmorId;
+      }
     }
 
     // Render

--- a/src/styles.css
+++ b/src/styles.css
@@ -509,6 +509,31 @@ button:active {
   user-select: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.cooldown-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0%;
+  background-color: rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  transition: height 0.1s linear;
+  z-index: 10;
+}
+
+.touch-btn:disabled {
+  opacity: 0.5;
+  filter: grayscale(100%);
+  pointer-events: none;
+  box-shadow: none;
+  transform: none;
 }
 
 .attack-btn {

--- a/src/ui.js
+++ b/src/ui.js
@@ -140,4 +140,39 @@ export class UI {
       }
     }
   }
+
+  updateActionButtons(weapon) {
+    const attackBtn = document.getElementById('attack-button');
+    const abilityBtn = document.getElementById('ability-button');
+    
+    // Disable if no weapon or if weapon is 'fist' (if that's the desired logic, 
+    // but the issue says "if no weapon is equipped". 
+    // Assuming 'fist' is the default "no weapon" state in some contexts, 
+    // but typically "no weapon equipped" means null.
+    // However, looking at CONFIG, 'FIST' is a weapon.
+    // The issue says: "if no weapon is equipped the attack/special buttons should be disabled"
+    // I will interpret this as weapon == null. 
+    // Wait, LocalPlayerController initializes with null weapon if not provided?
+    // Let's check LocalPlayerController again. 
+    // It says: weapon: data?.equipped_weapon || null.
+    // So null means no weapon.
+    
+    const disabled = !weapon;
+
+    if (attackBtn) attackBtn.disabled = disabled;
+    if (abilityBtn) abilityBtn.disabled = disabled;
+  }
+
+  updateCooldowns(attackPct, abilityPct) {
+    const attackOverlay = document.querySelector('#attack-button .cooldown-overlay');
+    const abilityOverlay = document.querySelector('#ability-button .cooldown-overlay');
+
+    if (attackOverlay) {
+      attackOverlay.style.height = `${attackPct * 100}%`;
+    }
+    
+    if (abilityOverlay) {
+      abilityOverlay.style.height = `${abilityPct * 100}%`;
+    }
+  }
 }

--- a/src/ui.test.js
+++ b/src/ui.test.js
@@ -29,6 +29,12 @@ describe('UI', () => {
       <div id="spectator-controls" class="hidden">
         <span id="spectating-name"></span>
       </div>
+      <button id="attack-button" class="touch-btn attack-btn">
+        <div class="cooldown-overlay"></div>
+      </button>
+      <button id="ability-button" class="touch-btn ability-btn">
+        <div class="cooldown-overlay"></div>
+      </button>
     `;
 
     ui = new UI();
@@ -289,6 +295,64 @@ describe('UI', () => {
     test('WhenZoneWarningNotFound_ShouldNotThrowError', () => {
       document.body.innerHTML = '';
       expect(() => ui.showZoneWarning(true)).not.toThrow();
+    });
+  });
+
+  describe('updateActionButtons', () => {
+    let attackBtn, abilityBtn;
+
+    beforeEach(() => {
+      attackBtn = document.getElementById('attack-button');
+      abilityBtn = document.getElementById('ability-button');
+    });
+
+    test('WhenWeaponProvided_ShouldEnableButtons', () => {
+      ui.updateActionButtons({ id: 'spear' });
+      expect(attackBtn.disabled).toBe(false);
+      expect(abilityBtn.disabled).toBe(false);
+    });
+
+    test('WhenNoWeaponProvided_ShouldDisableButtons', () => {
+      ui.updateActionButtons(null);
+      expect(attackBtn.disabled).toBe(true);
+      expect(abilityBtn.disabled).toBe(true);
+    });
+  });
+
+  describe('updateCooldowns', () => {
+    let attackOverlay, abilityOverlay;
+
+    beforeEach(() => {
+        // Need to manually add overlay elements to DOM mock for this test
+        const attackBtn = document.getElementById('attack-button');
+        const abilityBtn = document.getElementById('ability-button');
+        
+        // Ensure overlays exist
+        if (!attackBtn.querySelector('.cooldown-overlay')) {
+            const overlay = document.createElement('div');
+            overlay.className = 'cooldown-overlay';
+            attackBtn.appendChild(overlay);
+        }
+        if (!abilityBtn.querySelector('.cooldown-overlay')) {
+             const overlay = document.createElement('div');
+             overlay.className = 'cooldown-overlay';
+             abilityBtn.appendChild(overlay);
+        }
+
+        attackOverlay = document.querySelector('#attack-button .cooldown-overlay');
+        abilityOverlay = document.querySelector('#ability-button .cooldown-overlay');
+    });
+
+    test('WhenCooldownActive_ShouldUpdateOverlayHeight', () => {
+      ui.updateCooldowns(0.5, 0.2);
+      expect(attackOverlay.style.height).toBe('50%');
+      expect(abilityOverlay.style.height).toBe('20%');
+    });
+
+    test('WhenCooldownComplete_ShouldResetOverlay', () => {
+      ui.updateCooldowns(0, 0);
+      expect(attackOverlay.style.height).toBe('0%');
+      expect(abilityOverlay.style.height).toBe('0%');
     });
   });
 });


### PR DESCRIPTION
- Center text in touch buttons
- Add visual cooldown overlay to action buttons
- Disable action buttons when no weapon is equipped
- Sync button state and cooldowns with LocalPlayerController in game loop
- Add tests for UI updates and cooldown calculation
- Fixes #114
