### PR TITLE
fix: remove slash from Gemini resolve trigger

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   gemini:
-    if: github.event.issue.pull_request && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@gemini /resolve')
+    if: github.event.issue.pull_request && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association) && contains(github.event.comment.body, '@gemini resolve')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
This PR fixes the trigger condition in the Gemini workflow by removing the slash from `@gemini /resolve`, matching the actual usage in comments (`@gemini resolve`).