### PR TITLE
feat: add Supabase caching and refine Gemini trigger

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Save Supabase Docker Images
         if: steps.cache-supabase.outputs.cache-hit != 'true'
         run: |
-          docker save $(docker ps --format '{{.Image}}') -o /tmp/supabase-images.tar
+          docker save $(docker ps --format '{{.Image}}' | sort -u) -o /tmp/supabase-images.tar
 
       - name: Inject Gemini Credentials
         env:


### PR DESCRIPTION
This PR adds further improvements to the Gemini workflow:

- **Supabase Docker Caching**: Implements caching for Supabase Docker images to speed up workflow execution.
- **Trigger Refinement**: Ensures the workflow triggers on `@gemini resolve` (no slash) as intended.
- **Service Optimization**: Excludes unnecessary Supabase services in CI to reduce resource usage and startup time.
- **Credential Export**: Automatically exports Supabase API credentials to the environment for use by the Gemini Agent and tests.