### PR TITLE
test: fix flaky death flow E2E test by using mutable mock state

### DIFF
--- a/e2e/death.test.js
+++ b/e2e/death.test.js
@@ -29,6 +29,17 @@ describe('Player Death Flow E2E', () => {
 
     // Mock network and playersSnapshot to bypass real Supabase
     await page.evaluate(() => {
+      // Create a mutable state for the mock
+      window.mockState = {
+        players: new Map([['test-player', { 
+          player_id: 'test-player', 
+          player_name: 'TestPlayer',
+          health: 100,
+          position_x: 500,
+          position_y: 500
+        }]])
+      };
+
       // Create a more robust mock for network
       const mockNetwork = {
         playerId: 'test-player',
@@ -43,13 +54,7 @@ describe('Player Death Flow E2E', () => {
 
       const mockSnapshot = {
         ready: async () => {},
-        getPlayers: () => new Map([['test-player', { 
-          player_id: 'test-player', 
-          player_name: 'TestPlayer',
-          health: 100,
-          position_x: 500,
-          position_y: 500
-        }]]),
+        getPlayers: () => window.mockState.players,
         getInterpolatedPlayerState: (id) => ({
           x: 500,
           y: 500,
@@ -83,8 +88,13 @@ describe('Player Death Flow E2E', () => {
     const isSpectatorHidden = await page.$eval('#spectator-controls', el => el.classList.contains('hidden'));
     expect(isSpectatorHidden).toBe(true);
 
-    // 2. Simulate death by setting health to 0
+    // 2. Simulate death by setting health to 0 in both the player and the mock state
     await page.evaluate(() => {
+      const playerData = window.mockState.players.get('test-player');
+      if (playerData) {
+        playerData.health = 0;
+      }
+      
       if (window.game && window.game.localPlayerController) {
         const player = window.game.localPlayerController.getPlayer();
         if (player) {


### PR DESCRIPTION
## Description
Fixes flaky integration tests in `e2e/death.test.js` where the player death flow was timing out.

## Root Cause
The test used a static mock for `playersSnapshot`. In the game loop, `LocalPlayerController` synchronizes with the snapshot every frame. When the test manually set `player.health = 0`, the next frame's synchronization would overwrite it back to `100` from the static mock, preventing the death state from persisting long enough to trigger the spectator UI.

## Changes
- Refactored the mock setup in `e2e/death.test.js` to use a mutable `window.mockState` object.
- Updated the `getPlayers()` mock to return this mutable data.
- Updated the test logic to set health to 0 in both the local player instance AND the mock state, ensuring consistent state across synchronization cycles.

## Verification
- Ran `npm run test:e2e e2e/death.test.js` - PASSED consistently.
- Ran full suite `npm run test:e2e` - PASSED (no regressions).
