### PR TITLE
fix: resolve ReferenceError: CONFIG is not defined in UI.updateEquipment

### DIFF
--- a/src/renderer.test.js
+++ b/src/renderer.test.js
@@ -91,8 +91,8 @@ describe('Renderer', () => {
       expect(canvas.width).toBe(CONFIG.CANVAS.WIDTH);
       expect(canvas.height).toBe(CONFIG.CANVAS.HEIGHT);
 
-      // Should load background image + shadow image + 4 slash images + 5 weapon icons
-      expect(global.Image).toHaveBeenCalledTimes(11);
+      // Should load background image + shadow image + 4 slash images + 4 thrust images + 5 weapon icons
+      expect(global.Image).toHaveBeenCalledTimes(15);
       expect(newRenderer.bgImage.src).toBe('/game-background.png');
       expect(newRenderer.shadowImage.src).toBe('/shadow.png');
     });
@@ -543,8 +543,8 @@ describe('Renderer', () => {
 
       // Assert
 
-      // Should create shadow image + background image + slash images + weapon icons
-      expect(global.Image).toHaveBeenCalledTimes(11);
+      // Should create shadow image + background image + slash images + thrust images + weapon icons
+      expect(global.Image).toHaveBeenCalledTimes(15);
       expect(newRenderer.shadowImage).toBeDefined();
       expect(newRenderer.shadowImage.src).toBe('/shadow.png');
     });
@@ -854,8 +854,8 @@ describe('Renderer', () => {
 
         newRenderer.init();
 
-        // Should create background image + shadow image + slash images + weapon icons
-        expect(global.Image).toHaveBeenCalledTimes(11);
+        // Should create background image + shadow image + slash images + thrust images + weapon icons
+        expect(global.Image).toHaveBeenCalledTimes(15);
       });
 
     });

--- a/src/ui.js
+++ b/src/ui.js
@@ -3,6 +3,8 @@
  * Handles UI updates and screen transitions
  */
 
+import { CONFIG } from './config.js';
+
 export class UI {
   constructor() {
     this.screens = {

--- a/src/ui.test.js
+++ b/src/ui.test.js
@@ -268,6 +268,16 @@ describe('UI', () => {
       const equipmentDisplay = document.getElementById('equipment-display');
       expect(equipmentDisplay.innerHTML).toContain('Weapon: Super Sword');
     });
+
+    test('WhenWeaponHasIcon_ShouldUseConfigToBuildUrl', () => {
+      const weapon = { name: 'Spear', icon: 'spear.png' };
+      ui.updateEquipment(weapon, null);
+
+      const equipmentDisplay = document.getElementById('equipment-display');
+      const img = equipmentDisplay.querySelector('.weapon-icon');
+      expect(img).not.toBeNull();
+      expect(img.src).toContain('assets/weapons/spear.png');
+    });
   });
 
   describe('showZoneWarning', () => {


### PR DESCRIPTION
### Description
This PR fixes a critical crash in the UI system where picking up an item with an icon would cause a `ReferenceError: CONFIG is not defined`.

### Changes
- **src/ui.js**: Added missing import of `CONFIG`.
- **src/ui.test.js**: Added regression test `WhenWeaponHasIcon_ShouldUseConfigToBuildUrl` to ensure icon URLs are built correctly without crashing.
- **src/renderer.test.js**: Updated expected image load counts to account for recent additions of thrust VFX images (unrelated fix for broken tests).

### Verification
- [x] Unit tests pass: `npm test`
- [x] E2E tests pass: `npm run test:e2e`
- [x] Regression test confirms fix

Closes #176