### PR TITLE
feat: Export/Import input configs for frame-tool

### DIFF
--- a/tools/frame-tool/index.html
+++ b/tools/frame-tool/index.html
@@ -130,6 +130,14 @@
             </div>
             <button id="exportBtn" style="padding: 10px; background: #4a90e2; color: white; border: none; border-radius: 4px; cursor: pointer; margin-top: 10px;">Export Adjusted Sheet</button>
 
+            <div style="display: flex; gap: 10px; margin-top: 10px;">
+                <button id="saveProjectBtn" style="flex: 1; padding: 10px; background: #555; color: white; border: 1px solid #777; border-radius: 4px; cursor: pointer;">Save Config</button>
+                <label for="loadProjectInput" style="flex: 1; padding: 10px; background: #555; color: white; border: 1px solid #777; border-radius: 4px; cursor: pointer; text-align: center;">
+                    Load Config
+                    <input type="file" id="loadProjectInput" accept=".json" style="display: none;">
+                </label>
+            </div>
+
             <div class="preview-container">
                 <label>Preview</label>
                 <canvas id="previewCanvas" width="64" height="64"></canvas>
@@ -159,6 +167,9 @@
         </div>
     </div>
 
-    <script type="module" src="./src/app.js"></script>
+    <script type="module">
+        import { App } from './src/app.js';
+        new App();
+    </script>
 </body>
 </html>

--- a/tools/frame-tool/src/app.js
+++ b/tools/frame-tool/src/app.js
@@ -1,6 +1,6 @@
 import { FrameCalculator } from './FrameCalculator.js';
 
-class App {
+export class App {
     constructor() {
         this.calculator = new FrameCalculator();
         this.image = null;
@@ -22,6 +22,8 @@ class App {
             globalHeight: document.getElementById('globalHeight'),
         };
         this.exportBtn = document.getElementById('exportBtn');
+        this.saveProjectBtn = document.getElementById('saveProjectBtn');
+        this.loadProjectInput = document.getElementById('loadProjectInput');
         this.mainCanvas = document.getElementById('mainCanvas');
         this.previewCanvas = document.getElementById('previewCanvas');
         this.jsonOutput = document.getElementById('jsonOutput');
@@ -51,6 +53,8 @@ class App {
         });
 
         this.exportBtn.addEventListener('click', () => this.exportSpriteSheet());
+        this.saveProjectBtn.addEventListener('click', () => this.saveProject());
+        this.loadProjectInput.addEventListener('change', (e) => this.handleLoadProject(e));
         
         // Canvas click for setting anchor directly
         this.mainCanvas.addEventListener('mousedown', (e) => this.handleCanvasClick(e));
@@ -111,6 +115,37 @@ class App {
             globalWidth: parseInt(this.inputs.globalWidth.value) || 64,
             globalHeight: parseInt(this.inputs.globalHeight.value) || 64
         };
+    }
+
+    getProjectState() {
+        return {
+            config: this.getConfig(),
+            anchorOverrides: this.anchorOverrides,
+            frameOverrides: this.frameOverrides
+        };
+    }
+
+    loadProjectState(state) {
+        if (state.config) {
+            this.inputs.startX.value = state.config.startX;
+            this.inputs.startY.value = state.config.startY;
+            this.inputs.frameWidth.value = state.config.frameWidth;
+            this.inputs.frameHeight.value = state.config.frameHeight;
+            this.inputs.frameCount.value = state.config.frameCount;
+            this.inputs.fps.value = state.config.fps;
+            this.inputs.globalWidth.value = state.config.globalWidth;
+            this.inputs.globalHeight.value = state.config.globalHeight;
+        }
+        
+        if (state.anchorOverrides) {
+            this.anchorOverrides = state.anchorOverrides;
+        }
+        
+        if (state.frameOverrides) {
+            this.frameOverrides = state.frameOverrides;
+        }
+
+        this.update();
     }
 
     update() {
@@ -346,6 +381,32 @@ class App {
         jsonLink.click();
     }
 
+    saveProject() {
+        const state = this.getProjectState();
+        const blob = new Blob([JSON.stringify(state, null, 2)], {type: 'application/json'});
+        const link = document.createElement('a');
+        link.download = 'frame-tool-project.json';
+        link.href = URL.createObjectURL(blob);
+        link.click();
+    }
+
+    handleLoadProject(e) {
+        const file = e.target.files[0];
+        if (!file) return;
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            try {
+                const state = JSON.parse(e.target.result);
+                this.loadProjectState(state);
+            } catch (err) {
+                console.error('Failed to load project:', err);
+                alert('Invalid project file');
+            }
+        };
+        reader.readAsText(file);
+    }
+
     animate(timestamp) {
         if (this.image && this.frames.length > 0) {
             const config = this.getConfig();
@@ -398,5 +459,3 @@ class App {
         this.previewCtx.fillText(this.currentFrameIndex, 2, 11);
     }
 }
-
-new App();

--- a/tools/frame-tool/src/app.test.js
+++ b/tools/frame-tool/src/app.test.js
@@ -1,0 +1,100 @@
+import { jest } from '@jest/globals';
+import { App } from './app.js';
+import { FrameCalculator } from './FrameCalculator.js';
+
+describe('App State Management', () => {
+    let app;
+
+    beforeEach(() => {
+        // Setup DOM
+        document.body.innerHTML = `
+            <input type="file" id="imageInput">
+            <input type="number" id="startX" value="0">
+            <input type="number" id="startY" value="0">
+            <input type="number" id="frameWidth" value="32">
+            <input type="number" id="frameHeight" value="32">
+            <input type="number" id="frameCount" value="4">
+            <input type="number" id="fps" value="10">
+            <input type="number" id="globalWidth" value="64">
+            <input type="number" id="globalHeight" value="64">
+            <button id="exportBtn"></button>
+            <canvas id="mainCanvas"></canvas>
+            <canvas id="previewCanvas"></canvas>
+            <textarea id="jsonOutput"></textarea>
+            <div id="dropZone"></div>
+            <div id="overlayLayer"></div>
+            <button id="saveProjectBtn"></button>
+            <input type="file" id="loadProjectInput">
+        `;
+
+        // Mock canvas context
+        const mockContext = {
+            clearRect: jest.fn(),
+            drawImage: jest.fn(),
+            strokeRect: jest.fn(),
+            beginPath: jest.fn(),
+            moveTo: jest.fn(),
+            lineTo: jest.fn(),
+            stroke: jest.fn(),
+            fillRect: jest.fn(),
+            fillText: jest.fn(),
+        };
+        HTMLCanvasElement.prototype.getContext = jest.fn(() => mockContext);
+
+        app = new App();
+    });
+
+    test('getProjectState returns current config and overrides', () => {
+        // Set some values
+        app.inputs.startX.value = '10';
+        app.inputs.frameWidth.value = '64';
+        app.anchorOverrides = { 0: { x: 5, y: 5 } };
+        app.frameOverrides = { 1: { x: 20, y: 20 } };
+
+        const state = app.getProjectState();
+
+        expect(state).toEqual({
+            config: {
+                startX: 10,
+                startY: 0,
+                frameWidth: 64,
+                frameHeight: 32,
+                frameCount: 4,
+                fps: 10,
+                globalWidth: 64,
+                globalHeight: 64
+            },
+            anchorOverrides: { 0: { x: 5, y: 5 } },
+            frameOverrides: { 1: { x: 20, y: 20 } }
+        });
+    });
+
+    test('loadProjectState restores config and overrides', () => {
+        const state = {
+            config: {
+                startX: 50,
+                startY: 10,
+                frameWidth: 128,
+                frameHeight: 128,
+                frameCount: 8,
+                fps: 30,
+                globalWidth: 200,
+                globalHeight: 200
+            },
+            anchorOverrides: { 2: { x: 15, y: 15 } },
+            frameOverrides: { 3: { x: 40, y: 40 } }
+        };
+
+        app.loadProjectState(state);
+
+        expect(app.inputs.startX.value).toBe('50');
+        expect(app.inputs.startY.value).toBe('10');
+        expect(app.inputs.frameWidth.value).toBe('128');
+        expect(app.anchorOverrides).toEqual({ 2: { x: 15, y: 15 } });
+        expect(app.frameOverrides).toEqual({ 3: { x: 40, y: 40 } });
+        
+        // Should trigger update (we can check if calculator was called or just assume)
+        // Since we mocked FrameCalculator, we can check if calculateFrames was called if we wanted,
+        // but checking the state is enough.
+    });
+});


### PR DESCRIPTION
Implements the ability to save and load the frame tool's configuration (DOM inputs and overrides) to/from a JSON file.

Resolves #189

Changes:
- Refactored `App` class in `tools/frame-tool/src/app.js` to be exportable.
- Added `getProjectState` and `loadProjectState` methods for state management.
- Added 'Save Config' and 'Load Config' buttons to `tools/frame-tool/index.html`.
- Implemented file download/upload logic for the JSON configuration.
- Added unit tests in `tools/frame-tool/src/app.test.js`.