### PR TITLE
feat: include source filename in frame-tool export (#195)

### DIFF
--- a/tools/frame-tool/src/app.js
+++ b/tools/frame-tool/src/app.js
@@ -6,6 +6,7 @@ export class App {
     constructor() {
         this.calculator = new FrameCalculator();
         this.image = null;
+        this.sourceFilename = null;
         this.frames = [];
         this.currentFrameIndex = 0;
         this.lastFrameTime = 0;
@@ -119,6 +120,7 @@ export class App {
     handleFileSelect(file) {
         if (!file || !file.type.startsWith('image/')) return;
 
+        this.sourceFilename = file.name;
         const reader = new FileReader();
         reader.onload = (e) => {
             const img = new Image();
@@ -152,6 +154,7 @@ export class App {
     getProjectState() {
         return {
             config: this.getConfig(),
+            sourceFilename: this.sourceFilename,
             anchorOverrides: this.anchorOverrides,
             frameOverrides: this.frameOverrides
         };
@@ -167,6 +170,10 @@ export class App {
             this.inputs.fps.value = state.config.fps;
             this.inputs.globalWidth.value = state.config.globalWidth;
             this.inputs.globalHeight.value = state.config.globalHeight;
+        }
+
+        if (state.sourceFilename) {
+            this.sourceFilename = state.sourceFilename;
         }
         
         if (state.anchorOverrides) {
@@ -338,6 +345,7 @@ export class App {
     updateJSON(config) {
         // Construct a JSON object compatible with the project's spritesheet format
         let output = {
+            sourceFilename: this.sourceFilename,
             frameWidth: config.frameWidth,
             frameHeight: config.frameHeight
         };
@@ -405,6 +413,7 @@ export class App {
 
         // Download JSON
         const exportJSON = {
+            sourceFilename: this.sourceFilename,
             frameWidth: config.globalWidth,
             frameHeight: config.globalHeight,
             columns: this.frames.length,

--- a/tools/frame-tool/src/app.test.js
+++ b/tools/frame-tool/src/app.test.js
@@ -25,6 +25,14 @@ describe('App State Management', () => {
             <div id="overlayLayer"></div>
             <button id="saveProjectBtn"></button>
             <input type="file" id="loadProjectInput">
+            
+            <input type="checkbox" id="bgRemoveEnabled">
+            <div id="bgRemoveControls" style="display: none;">
+                <input type="color" id="bgKeyColor" value="#00ff00">
+                <input type="text" id="bgKeyColorText" value="#00ff00">
+                <input type="range" id="bgThreshold" value="0">
+                <span id="bgThresholdVal">0</span>
+            </div>
         `;
 
         // Mock canvas context
@@ -64,6 +72,7 @@ describe('App State Management', () => {
                 globalWidth: 64,
                 globalHeight: 64
             },
+            sourceFilename: null,
             anchorOverrides: { 0: { x: 5, y: 5 } },
             frameOverrides: { 1: { x: 20, y: 20 } }
         });
@@ -96,5 +105,39 @@ describe('App State Management', () => {
         // Should trigger update (we can check if calculator was called or just assume)
         // Since we mocked FrameCalculator, we can check if calculateFrames was called if we wanted,
         // but checking the state is enough.
+    });
+
+    test('captures filename when image is selected and includes it in project state', () => {
+        const file = new File([''], 'test-spritesheet.png', { type: 'image/png' });
+        
+        // Mock FileReader
+        const mockFileReaderInstance = {
+            readAsDataURL: jest.fn(function() {
+                this.onload({ target: { result: 'data:image/png;base64,' } });
+            }),
+            onload: null
+        };
+        global.FileReader = jest.fn(() => mockFileReaderInstance);
+        
+        // Mock Image
+        const mockImage = {};
+        global.Image = jest.fn(() => mockImage);
+
+        app.handleFileSelect(file);
+
+        expect(app.sourceFilename).toBe('test-spritesheet.png');
+        
+        const state = app.getProjectState();
+        expect(state.sourceFilename).toBe('test-spritesheet.png');
+
+        // Simulate loading project with filename
+        const newState = {
+            config: {},
+            sourceFilename: 'other-image.png',
+            anchorOverrides: {},
+            frameOverrides: {}
+        };
+        app.loadProjectState(newState);
+        expect(app.sourceFilename).toBe('other-image.png');
     });
 });


### PR DESCRIPTION
This PR implements the requirement to include the source image filename in the Frame Tool's exported JSON and project state.

### Changes:
- **Captured source filename**: Added logic to `handleFileSelect` to store the filename of the loaded image.
- **Project State persistence**: Updated `getProjectState` and `loadProjectState` to include `sourceFilename` in the saved project configuration.
- **Exported JSON**: Added `sourceFilename` to the JSON output in both `updateJSON` (live preview) and `exportSpriteSheet` (final export).
- **Test Environment Fixes**: Added missing UI elements to the test setup in `app.test.js` to fix pre-existing failures.
- **New Tests**: Added test cases to verify that the filename is correctly captured and persisted in the state.

Closes #195