### PR TITLE
feat: Export/Import background removal settings in Frame Tool (#199)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "puppeteer": "^24.34.0",
         "sharp": "^0.34.5",
         "supabase": "^2.71.0",
-        "tailwindcss": "3.4",
+        "tailwindcss": "^3.4.19",
         "vite": "^5.4.11"
       }
     },

--- a/tools/frame-tool/src/app.js
+++ b/tools/frame-tool/src/app.js
@@ -156,7 +156,11 @@ export class App {
             config: this.getConfig(),
             sourceFilename: this.sourceFilename,
             anchorOverrides: this.anchorOverrides,
-            frameOverrides: this.frameOverrides
+            frameOverrides: this.frameOverrides,
+            background: {
+                color: this.bgKeyColor.value,
+                threshold: parseInt(this.bgThreshold.value)
+            }
         };
     }
 
@@ -182,6 +186,13 @@ export class App {
         
         if (state.frameOverrides) {
             this.frameOverrides = state.frameOverrides;
+        }
+
+        if (state.background) {
+            this.bgKeyColor.value = state.background.color;
+            this.bgKeyColorText.value = state.background.color;
+            this.bgThreshold.value = state.background.threshold;
+            this.bgThresholdVal.textContent = state.background.threshold;
         }
 
         this.update();

--- a/tools/frame-tool/src/app.test.js
+++ b/tools/frame-tool/src/app.test.js
@@ -30,7 +30,7 @@ describe('App State Management', () => {
             <div id="bgRemoveControls" style="display: none;">
                 <input type="color" id="bgKeyColor" value="#00ff00">
                 <input type="text" id="bgKeyColorText" value="#00ff00">
-                <input type="range" id="bgThreshold" value="0">
+                <input type="range" id="bgThreshold" min="0" max="255" value="0">
                 <span id="bgThresholdVal">0</span>
             </div>
         `;
@@ -74,7 +74,11 @@ describe('App State Management', () => {
             },
             sourceFilename: null,
             anchorOverrides: { 0: { x: 5, y: 5 } },
-            frameOverrides: { 1: { x: 20, y: 20 } }
+            frameOverrides: { 1: { x: 20, y: 20 } },
+            background: {
+                color: '#00ff00',
+                threshold: 0
+            }
         });
     });
 
@@ -139,5 +143,34 @@ describe('App State Management', () => {
         };
         app.loadProjectState(newState);
         expect(app.sourceFilename).toBe('other-image.png');
+    });
+
+    test('getProjectState includes background removal settings', () => {
+        app.bgKeyColor.value = '#ff00ff';
+        app.bgThreshold.value = '150';
+
+        const state = app.getProjectState();
+
+        expect(state.background).toEqual({
+            color: '#ff00ff',
+            threshold: 150
+        });
+    });
+
+    test('loadProjectState restores background removal settings', () => {
+        const state = {
+            config: {},
+            background: {
+                color: '#0000ff',
+                threshold: 75
+            }
+        };
+
+        app.loadProjectState(state);
+
+        expect(app.bgKeyColor.value).toBe('#0000ff');
+        expect(app.bgKeyColorText.value).toBe('#0000ff');
+        expect(app.bgThreshold.value).toBe('75');
+        expect(app.bgThresholdVal.textContent).toBe('75');
     });
 });


### PR DESCRIPTION
This PR adds support for exporting and importing background removal settings (key color and threshold) in the Frame Tool's project configuration.

### Changes
- Updated `app.js` to include `background` info in `getProjectState` and `loadProjectState`.
- Updated UI to restore background settings upon loading a project.
- Added unit tests in `app.test.js` to verify the new functionality.
- Updated existing tests to handle the new state structure.

Closes #199