### PR TITLE
fix: make E2E test port selection deterministic

### DIFF
--- a/scripts/port-utils.js
+++ b/scripts/port-utils.js
@@ -74,10 +74,8 @@ export async function isPortAvailable(port) {
  */
 export async function getAvailablePort(basePort) {
   const hash = getBranchHash();
-  // Add a random offset between 0 and 99 to reduce collision probability when multiple processes
-  // start at the same time on the same branch.
-  const randomOffset = Math.floor(Math.random() * 100);
-  const startPort = basePort + hash + randomOffset;
+  // Remove random offset to ensure deterministic port selection for tests
+  const startPort = basePort + hash;
   let port = startPort;
   
   // Try up to 100 ports to find a free one

--- a/scripts/port-utils.test.js
+++ b/scripts/port-utils.test.js
@@ -40,24 +40,12 @@ describe('Port Utilities', () => {
   });
 
   describe('getAvailablePort', () => {
-    let originalMathRandom;
-
-    beforeEach(() => {
-      originalMathRandom = Math.random;
-      // Mock Math.random to return 0, ensuring offset is 0 for deterministic testing
-      Math.random = () => 0;
-    });
-
-    afterEach(() => {
-      Math.random = originalMathRandom;
-    });
-
     test('should return a port in the expected range', async () => {
       const basePort = 3000;
       const port = await getAvailablePort(basePort);
       const hash = getBranchHash();
       
-      // With random() mocked to 0, the offset is 0
+      // deterministic behavior
       expect(port).toBeGreaterThanOrEqual(basePort + hash);
       expect(port).toBeLessThan(basePort + hash + 100);
     });
@@ -65,7 +53,7 @@ describe('Port Utilities', () => {
     test('should return a different port if the hashed one is taken', async () => {
       const basePort = 20000;
       const hash = getBranchHash();
-      // With random() mocked to 0, offset is 0
+      // deterministic behavior
       const hashedPort = basePort + hash;
       
       const server = net.createServer();
@@ -86,7 +74,7 @@ describe('Port Utilities', () => {
     test('should throw an error if no port is available', async () => {
       const basePort = 21000;
       const hash = getBranchHash();
-      // With random() mocked to 0, offset is 0
+      // deterministic behavior
       const startPort = basePort + hash;
       const servers = [];
 


### PR DESCRIPTION
Removed random offset from getAvailablePort to ensure consistent port usage per branch. Updated tests to remove Math.random mocking.
